### PR TITLE
Fix transaction value floating point precision bug

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -116,6 +116,7 @@ const DOM = {
 const Utils = {
     formatAmount(value){
         value = Number(value.replace(/\,\./g, "")) * 100
+        value = Math.trunc(value);
         
         return value
     },


### PR DESCRIPTION
When registering new transactions, there is a floating point precision bug when entering values like: (`16,01`, `32,02`, `64,04`, `128,08`...) and so on.
For example, when adding a transaction with the value `32,02` the value will be formatted as `3202,0000000000005` and the transaction will be saved with the value `320.200.000.000.000,06`.